### PR TITLE
Add development tools to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN dnf makecache \
     sudo \
     which \
     python3-dnf \
+    python-devel \
+    libffi-devel \
+  && dnf -y groupinstall "Development Tools" \
   && dnf clean all
 
 # Install Ansible via Pip.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,14 @@ RUN dnf -y install systemd && dnf clean all && \
 # Install pip and other requirements.
 RUN dnf makecache \
   && dnf -y install \
+    libffi-devel \
+    python3-dnf \
+    python3-devel \
     python3-pip \
+    python3-setuptools \
+    python3-wheel \
     sudo \
     which \
-    python3-dnf \
-    python-devel \
-    libffi-devel \
   && dnf -y groupinstall "Development Tools" \
   && dnf clean all
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds the `dnf` group "Development Tools" to the image and closes #1.

## 💭 Motivation and Context

The "Development Tools" group, along with `python-devel` and `libffi-devel`, appear to be necessary for building `pip` modules now.

## 🧪 Testing

I rebuilt the image with these changes, pushed it to Docker Hub, and verified that [this GitHub Action](https://github.com/cisagov/ansible-role-pca-gophish-composition/runs/754592031) now passes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
